### PR TITLE
chore(deps): bump harbor from 2.8.2 to 2.14.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 ###
 # GENERAL
 #
-harbor_version_release: 2.8.2
+harbor_version_release: 2.14.2
 harbor_version_config: 2.8.0
 harbor_installation_dir: /etc/harbor
 harbor_http_port: 80


### PR DESCRIPTION
Automated Harbor version bump.

- **Current version**: 2.8.2
- **New version**: 2.14.2
- **Release**: https://github.com/goharbor/harbor/releases/tag/v2.14.2