### PR TITLE
fix(deps): bump harbor from 2.14.2 to 2.15.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 ###
 # GENERAL
 #
-harbor_version_release: 2.14.2
-harbor_version_config: 2.14.0
+harbor_version_release: 2.15.0
+harbor_version_config: 2.15.0
 harbor_installation_dir: /etc/harbor
 harbor_http_port: 80
 harbor_admin_password: ''


### PR DESCRIPTION
Automated Harbor version bump.

- **Current version**: 2.14.2
- **New version**: 2.15.0
- **Release**: https://github.com/goharbor/harbor/releases/tag/v2.15.0